### PR TITLE
Adjusting header image size to be dynamic

### DIFF
--- a/frontend/src/scss/app.scss
+++ b/frontend/src/scss/app.scss
@@ -15,7 +15,8 @@
 #header {
     .image {
         background-image: url("../public/images/header_1920_450.jpg");
-        height: 300px;
+        background-size: 100% 100%;
+        padding-top: 25%;
     }
 
     //font-size: 125%;


### PR DESCRIPTION
Currently, the header image's style is hard-coded to 300px tall. This makes the image basically unviewable on mobile devices in portrait mode. It also chops off some of the image's right side on desktops.

Adjusting the header image's background-size property to scale with the size of the div, and changing `height: 300px` to `padding-top: 25%` to maintain aspect ratio with the width of the parent div.

Desktop (Old)
![image](https://user-images.githubusercontent.com/5304579/93553674-3708d800-f939-11ea-9812-dafbe9259f26.png)

Desktop (New)
![image](https://user-images.githubusercontent.com/5304579/93553650-26f0f880-f939-11ea-9362-03fea344010f.png)

Mobile Portrait Mode (Old)
![image](https://user-images.githubusercontent.com/5304579/93553518-cd88c980-f938-11ea-87e9-3afc57072602.png)

Mobile Portrait Mode (New)
![image](https://user-images.githubusercontent.com/5304579/93553598-00cb5880-f939-11ea-94fc-18bf1559d670.png)
